### PR TITLE
setup script: add single quote to escape the char

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,4 +19,4 @@ pip install -r requirements/requirements.txt
 ALIAS_CMD="alias kq_env='cd $PROJECT_DIRECTORY && source kq_env/bin/activate'"
 echo "$ALIAS_CMD" >> ~/.bash_profile
 
-echo "Setup complete, run `source ~/.bash_profile` use kq_env to enter the dev environment in the future!"
+echo 'Setup complete, run `source ~/.bash_profile` use `kq_env` to enter the dev environment in the future!'


### PR DESCRIPTION
Fixes the log line, otherwise strings between backticks are cut out.