### PR TITLE
exclusion set: fix matching when user names contain spaces

### DIFF
--- a/src/assignment.py
+++ b/src/assignment.py
@@ -135,6 +135,16 @@ def _players_to_assignment(players: List[Player], role: PlayerRole) -> List[Play
     return [PlayerAssignment(player=p, assigned_role=role) for p in players]
 
 
+def _contains_exclusion_set(players: Set[Player], exclusion_set: List[Set[str]]) -> Optional[Set[str]]:
+    """Check if the set of players violates an exclusion set."""
+    players_to_check = {p.name.lower() for p in players}
+    for exclusion in exclusion_set:
+        exclusion_to_compare = {elem.lower() for elem in exclusion}
+        if exclusion_to_compare.issubset(players_to_check):
+            return exclusion
+    return None
+
+
 def _get_match_exclusion_set_players(
     all_players: List[Player], group: _PlayerGroup, exclusion_set: List[Set[str]]
 ) -> Set[str]:
@@ -142,12 +152,9 @@ def _get_match_exclusion_set_players(
     to_exclude: Set[str] = set()
     for player in all_players:
         # TODO this lower is kind of annoying maybe we should standardize somehow
-        possible_team = {p.player.name.lower() for p in group.players} | {player.name.lower()}
-        for exclusion in exclusion_set:
-            exclusion_to_compare = {elem.lower() for elem in exclusion}
-            if exclusion_to_compare.issubset(possible_team):
-                to_exclude.add(player.name)
-                break
+        possible_team = set([p.player for p in group.players] + [player])
+        if _contains_exclusion_set(possible_team, exclusion_set) is not None:
+            to_exclude.add(player.name)
     return to_exclude
 
 
@@ -242,6 +249,7 @@ def _assign_players_with_exclusion_set(
     groups_without_exclusion = []
     for group in groups_to_assign:
         group_exclusion_set = _get_match_exclusion_set_players(possible_players, group, exclusion_set)
+        print(f"Excluding {group_exclusion_set} for group {group}")
         if len(group_exclusion_set) > 0:
             groups_with_exclusion.append(_GroupWithExclusions(group=group, to_exclude=group_exclusion_set))
         else:
@@ -314,6 +322,9 @@ def assign_players_to_teams(
     players_to_select = list(players)
     # Remove the people in the inclusion set from the overall set
     for inclusion in inclusion_set:
+        excluded = _contains_exclusion_set({p.player for p in inclusion}, exclusion_set)
+        if excluded is not None:
+            raise ValueError(f"Can't assign teams when inclusion set: {inclusion} violates exclusion set: {excluded}")
         players_to_select = _remove_subset_from_players(players_to_select, inclusion)
 
     # Create the initial player groups, account for the inclusion set

--- a/src/data/attendance.csv
+++ b/src/data/attendance.csv
@@ -1,25 +1,25 @@
-Player,Queen,Obj
-Blue Chris,1,
-David,,1
-Josh,,
-Chaz,,1
-DRay,1,
-Matt,,
-Jasmine,,1
-Felix,,
-Scott,,
-Ben,,
-Turese,,1
-Jess,,1
-Coki,,
-Steve,,1
-BrianM,,
-Ryan,1,
-Sam,,
-Charles,,
-Brad,,
-Keoni,,
-Drew,1,
-Dan,,
-BLee,,
-Derek M,,
+Player,Queen,Drone,Rand
+Dray,1,,0.07441328336
+Blue Chris,,,0.1920133473
+Matt,,,0.2180991683
+Turese,,,0.7379951185
+Jess,1,,0.3222475512
+Coki,,,0.5013520031
+Brian Lee,,1,0.2491275366
+Jasmine,,,0.484965363
+Steve,,,0.4085907222
+Brian M,,,0.1676416272
+Josh,1,,0.1635849595
+Charles,,,0.7973875813
+Sam,,,0.3673897494
+Brad,,,0.8175341534
+Dan,1,,0.7868504221
+Drew,,1,0.07261948033
+Andrew,,1,0.9266331176
+Chaz,1,,0.8290362141
+Mo,,1,0.04497894581
+Mitch,,,0.7342900726
+Reed,,1,0.9113265542
+Felix,,,
+Scott,,,
+Keoni,,,

--- a/src/data_types/team.py
+++ b/src/data_types/team.py
@@ -30,7 +30,7 @@ class TeamComposition:
         counts: Dict[PlayerRole, int] = defaultdict(int)
         for role in cls.roles:
             counts[role] += 1
-        return [(role, counts[role]) for role in cls.roles]
+        return [(role, counts[role]) for role in counts]
 
     @classmethod
     def total_score_for_ranking(cls, ranking: Dict[PlayerRole, float]) -> float:

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -72,8 +72,8 @@ def load_data(csv_path: str) -> Dict[str, Player]:
             # convert values to floats
             float_ranking_dict = {key: _try_to_float(value) for key, value in ranking_dict.items()}
 
-            name = row["name"]
-            to_return[name.lower().strip()] = Player(
+            name = row["name"].strip()
+            to_return[name.lower()] = Player(
                 name=name,
                 primary_role=primary_role,
                 ranking=float_ranking_dict,

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ def assign(file_path: str) -> None:
 
     inclusion_set = load_inclusion_set("data/inclusion_set.csv", player_infos)
     exclusion_set = load_exclusion_set("data/exclusion_set.csv", all_names)
+    print(f"Loaded exclusion set: {exclusion_set}")
     teams = assign_players_to_teams(all_players, inclusion_set, exclusion_set)
     teams = sorted(teams, key=lambda t: t.total_score)
     for t in teams:

--- a/src/tests/test_assignment.py
+++ b/src/tests/test_assignment.py
@@ -2,7 +2,7 @@ from typing import Set
 
 import pytest
 
-from src.assignment import assign_players_to_teams
+from src.assignment import _contains_exclusion_set, assign_players_to_teams
 from src.data_types.player import Player, PlayerAssignment, PlayerRole
 from src.data_types.team import Team
 
@@ -15,6 +15,17 @@ def _player_one_role(name: str, player_role: PlayerRole, ranking: int) -> Player
 
 def _team_to_player_names(team: Team) -> Set[str]:
     return {p.player.name for p in team.players}
+
+
+def test_contains_exclusion_set() -> None:
+    players = [
+        _player_one_role("A", PlayerRole.QUEEN, 5),
+        _player_one_role("B", PlayerRole.SPEED, 5),
+        _player_one_role("C", PlayerRole.OBJECTIVE, 5),
+    ]
+    assert _contains_exclusion_set(set(players), [{"A", "B"}]) == {"A", "B"}
+    assert _contains_exclusion_set(set(players), [{"C", "D"}]) is None
+    assert _contains_exclusion_set(set(players), [{"A", "B"}, {"A", "C"}]) == {"A", "B"}
 
 
 def test_happy_assignment() -> None:


### PR DESCRIPTION
Add a `strip`, checked manually that this works now.