### PR TITLE
sampling: allow randomness when sampling players

### DIFF
--- a/src/assignment.py
+++ b/src/assignment.py
@@ -170,6 +170,7 @@ def _get_player_for_ideal_score(
         players_minus_exclusion = player_assignments
     # Get as close to the ideal score as possible
     sorted_players = sorted(players_minus_exclusion, key=lambda p: abs(ideal_score - p.weighted_score))
+    print([abs(ideal_score - p.weighted_score) for p in sorted_players])
     if len(sorted_players) == 0:
         return None
     return sorted_players[0]
@@ -223,6 +224,7 @@ def _assign_players_with_exclusion_set(
     role: PlayerRole,
     exclusion_set: List[Set[str]],
     role_averages: Dict[PlayerRole, float],
+    use_uniform_sampling: bool,
 ) -> List[PlayerAssignment]:
     """Assign players to teams, accounting for the exclusion set.
 
@@ -294,9 +296,10 @@ def _assign_players_with_exclusion_set(
             f"ideal score: {ideal_score}"
         )
 
-    sampled_players = sample_players(
-        PlayerSamplingStrategy.UNIFORM_SCORE, possible_players, len(groups_without_exclusion), role
+    sampling_strategy = (
+        PlayerSamplingStrategy.RANDOM if not use_uniform_sampling else PlayerSamplingStrategy.UNIFORM_SCORE
     )
+    sampled_players = sample_players(sampling_strategy, possible_players, len(groups_without_exclusion), role)
     # Anecdotally, it seems to work better to sort by the player scores in this order.
     sampled_players = sorted(sampled_players, key=_sort_by_score_fn)
     groups_without_exclusion = sorted(groups_without_exclusion, key=_sort_by_score_fn, reverse=True)
@@ -312,7 +315,10 @@ def _assign_players_with_exclusion_set(
 
 
 def assign_players_to_teams(
-    players: Set[Player], inclusion_set: List[List[PlayerAssignment]], exclusion_set: List[Set[str]]
+    players: Set[Player],
+    inclusion_set: List[List[PlayerAssignment]],
+    exclusion_set: List[Set[str]],
+    use_uniform_sampling: bool = False,
 ) -> List[Team]:
     # Find the minimum number of teams required.
     total_teams = math.ceil(len(players) / 5)
@@ -365,6 +371,7 @@ def assign_players_to_teams(
             player_role,
             exclusion_set,
             role_averages,
+            use_uniform_sampling,
         )
         players_to_select = _remove_subset_from_players(players_to_select, assigned_players)
 

--- a/src/sampling.py
+++ b/src/sampling.py
@@ -13,6 +13,7 @@ class PlayerSamplingStrategy(enum.Enum):
     PRIORITIZE_HIGHEST_SCORE = 1
     ONLY_PREFERRED_ROLE = 2
     UNIFORM_SCORE = 3
+    RANDOM = 4
 
 
 def get_players_for_role(all_players: List[Player], role: PlayerRole) -> List[PlayerAssignment]:
@@ -114,4 +115,9 @@ def sample_players(
         return _sample_players_only_preferred_role(players, num_required, role)
     elif player_sampling_strategy == PlayerSamplingStrategy.UNIFORM_SCORE:
         return _sample_players_uniform(players, num_required, role)
+    elif player_sampling_strategy == PlayerSamplingStrategy.RANDOM:
+        return [
+            PlayerAssignment(player=p, assigned_role=role)
+            for p in random.sample(players, min(len(players), num_required))
+        ]
     raise NotImplementedError(f"No sampling strategy defined for enum: {player_sampling_strategy}")

--- a/src/tests/test_assignment.py
+++ b/src/tests/test_assignment.py
@@ -118,7 +118,7 @@ def test_inclusion_set() -> None:
     with pytest.raises(ValueError):
         assign_players_to_teams(all_players, inclusion_set, [])
     inclusion_set = [[PlayerAssignment(b_player, PlayerRole.FLEX), PlayerAssignment(c_player, PlayerRole.OBJECTIVE)]]
-    teams = assign_players_to_teams(all_players, [], [])
+    teams = assign_players_to_teams(all_players, [], [], use_uniform_sampling=True)
     # Sort by team name (queen name)
     teams.sort(key=lambda team: team.team_name)
     team_player_names = _team_to_player_names(teams[0])
@@ -126,7 +126,8 @@ def test_inclusion_set() -> None:
     team_player_names = _team_to_player_names(teams[1])
     assert "C" not in team_player_names and "B" in team_player_names
 
-    teams = assign_players_to_teams(all_players, inclusion_set, [])
+    # Disable random sampling so it is deterministic
+    teams = assign_players_to_teams(all_players, inclusion_set, [], use_uniform_sampling=True)
     teams.sort(key=lambda team: team.team_name)
     # should be on the second team since the second team has the weaker queen
     team_player_names = _team_to_player_names(teams[1])


### PR DESCRIPTION
Random sampling when selecting the set of players to choose from for NON-exclusion set teams.

Logic still tries to select the "best" player from that set for each team.