### PR TITLE
assignment: fix loading the exclusion data

### DIFF
--- a/src/assignment.py
+++ b/src/assignment.py
@@ -159,21 +159,29 @@ def _validate_required_roles(
             )
 
 
-def _players_to_assignment(players: List[Player], role: PlayerRole) -> List[PlayerAssignment]:
-    return [PlayerAssignment(player=p, assigned_role=role) for p in players]
-
-
 def _contains_exclusion_set(players: PlayerPool, exclusion_set: list[Exclusion]) -> Optional[PlayerPool]:
-    """Check if the set of players violates an exclusion set."""
+    """Check if the set of players violates an exclusion set.
+
+    If the players in PlayerPool contains an exclusion set, return the set of players that violate the exclusion set.
+    """
+    player_names = [p.name for p in players.players]
     for exclusion in exclusion_set:
+        exclusion_names = {exclusion.requester.name, exclusion.other_player.name}
+        if set(player_names) == {"Chaz", "Felix"} and ("Chaz" in exclusion_names and "Felix" in exclusion_names):
+            import ipdb
+
+            ipdb.set_trace()
+
         if players.contains_pool(exclusion.player_pool):
             if exclusion.only_if_they_queen:
-                # We need to confirm that the second player wants to queen.  That means they must be the first queen
-                # found in the existing player_pool as well
+                # If only_if_they_queen is set to True, then the exclusion only applies if specifically the SECOND player in the
+                # exclusion is queening. If neither players are queens, then the exclusion does not apply.
                 queen_pool = PlayerPool.filter(players, [PlayerRole.QUEEN])
                 other_name = exclusion.other_player.name
-                if (queen_pool.contains_player(other_name) and
-                        queen_pool.get_player(other_name) == queen_pool.players[0]):
+                if (
+                    queen_pool.contains_player(other_name)
+                    and queen_pool.get_player(other_name) == queen_pool.players[0]
+                ):
                     return exclusion.player_pool
             else:
                 return exclusion.player_pool

--- a/src/data_types/exclusion.py
+++ b/src/data_types/exclusion.py
@@ -1,8 +1,9 @@
-from src.data_types.player import Player, PlayerRole
+from src.data_types.player import Player
 from src.data_types.player_pool import PlayerPool
 
+
 class Exclusion:
-    """Two players who will not play together, at least given certain criteria
+    """Two players who will not play together, at least given certain criteria.
 
     Behind the scenes it is implemented using a PlayerPool, as that handles all the weirdness around names
     """
@@ -14,4 +15,4 @@ class Exclusion:
         self.only_if_they_queen = only_if_they_queen
 
     def __str__(self) -> str:
-        return f"Exclusion({self.requester}, {self.other_player}, {self.only_if_they_queen})"
+        return f"Exclusion({self.requester.name}, {self.other_player.name}, {self.only_if_they_queen})"

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -81,6 +81,14 @@ def load_attendance(csv_path: str, player_pool: PlayerPool) -> PlayerPool:
     return PlayerPool(player_list)
 
 
+def _str_to_bool(value: str) -> bool:
+    if value == "TRUE":
+        return True
+    if value == "FALSE":
+        return False
+    raise ValueError(f"Could not convert {value} to boolean, must be one of 'TRUE' or 'FALSE'")
+
+
 def load_exclusion_set(csv_path: str, player_pool: PlayerPool) -> list[Exclusion]:
     """Given a csv, load sets of people who should not play on the same team."""
     exclusion_set = []
@@ -96,7 +104,7 @@ def load_exclusion_set(csv_path: str, player_pool: PlayerPool) -> list[Exclusion
 
             only_if_they_queen = False
             if len(row) > 2:
-                only_if_they_queen = bool(row[2])
+                only_if_they_queen = _str_to_bool(row[2])
 
             exclusion_set.append(Exclusion(requestor, other_player, only_if_they_queen))
 

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,7 @@ def assign(file_path: str) -> None:
 
     inclusion_set = load_inclusion_set("data/inclusion_set.csv", player_pool)
     exclusion_set = load_exclusion_set("data/exclusion_set.csv", player_infos)
-    print(f"Loaded exclusion set: {[[p.name for p in e.player_pool.players] for e in exclusion_set]}")
+    print(f"Loaded exclusion set: {', '.join([str(e) for e in exclusion_set])}")
     teams = assign_players_to_teams(player_pool, inclusion_set, exclusion_set)
     teams = sorted(teams, key=lambda t: t.total_score)
     for t in teams:


### PR DESCRIPTION
We were just casting to bool but because Python uses truthy and falsey values, any non-empty string will be cast to `True`, and only empty strings will be cast to `False`. We were use `"TRUE"` and `"FALSE"` in the exclusion set csv, meaning everyone was being incorrectly loaded as `only_if_they_queen=True`. I manually tested that this works.